### PR TITLE
Use Ruby 2.0.0 for all Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
-matrix:
-  include:
-    - rvm: 2.0.0
-    - env: RACK_VERSION="~> 1.4.0"
-    - env: RACK_VERSION="~> 1.3.0"
-    - env: RACK_VERSION="~> 1.2.0"
+rvm: 2.0.0
+env:
+  - RACK_VERSION="~> 1.4.0"
+  - RACK_VERSION="~> 1.3.0"
+  - RACK_VERSION="~> 1.2.0"

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-ShamRack
+ShamRack [![Build Status](https://secure.travis-ci.org/mdub/sham_rack.png?branch=master)](http://travis-ci.org/mdub/sham_rack)
 ========
 
 ShamRack plumbs HTTP requests into [Rack][rack].


### PR DESCRIPTION
- Old travis.yml used ruby 2.0.0 for one build, 1.9.3 (default) for rest
- New travis.yml more clearly shows ruby version being tested against
- Add travis build status badge to README
- View of new output: https://travis-ci.org/jessieay/sham_rack/
