### PR TITLE
gemspec: Drop rubyforge_project directive

### DIFF
--- a/sham_rack.gemspec
+++ b/sham_rack.gemspec
@@ -7,11 +7,9 @@ Gem::Specification.new do |gem|
   gem.summary = "Net::HTTP-to-Rack plumbing"
   gem.description = "ShamRack plumbs Net::HTTP directly into Rack, for quick and easy HTTP testing."
 
-  gem.homepage = "http://github.com/mdub/sham_rack"
+  gem.homepage = "https://github.com/mdub/sham_rack"
   gem.authors = ["Mike Williams"]
   gem.email = "mdub@dogbiscuit.org"
-
-  gem.rubyforge_project = "shamrack"
 
   gem.version = ShamRack::VERSION.dup
   gem.platform = Gem::Platform::RUBY


### PR DESCRIPTION
This is now unused by RubyGems.org.

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property

[1]: https://twitter.com/evanphx/status/399552820380053505